### PR TITLE
fix broken Service dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,14 @@
 class systemd {
 
-  exec { 'systemd-daemon-reload':
-    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-    command     => 'systemctl daemon-reload',
-    refreshonly => true,
-    before      => Class['service'],
+  if $::systemd_available {
+    exec { 'systemd-daemon-reload':
+      path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command     => 'systemctl daemon-reload',
+      refreshonly => true
+    }
+
+   # refresh systemd before every service
+   Exec['systemd-daemon-reload'] -> Service<| |>
   }
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,14 @@
 class systemd {
 
-  if $::systemd_available {
+  if ( str2bool("$::systemd_available") ) {
     exec { 'systemd-daemon-reload':
       path        => '/bin:/usr/bin:/sbin:/usr/sbin',
       command     => 'systemctl daemon-reload',
       refreshonly => true
     }
 
-   # refresh systemd before every service
-   Exec['systemd-daemon-reload'] -> Service<| |>
+    # refresh systemd before every service
+    Exec['systemd-daemon-reload'] -> Service<| |>
   }
 
   case $::osfamily {


### PR DESCRIPTION
The `before => Class['service']`syntsx doesn't work, at least for me with Puppet 3.8, so I implemented the generic dependency of systemd refresh on every service. Plus, I do it only if systemd is present because I prefer to be able to safely include the main systemd class in every host, cause I know it won't do anything harmful if systemd is not present. But we can discuss this, if you think this logic should be outside of the module
