### PR TITLE
Remove refresh of Exec[systemd-daemon-reload] for every service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,9 +9,6 @@ class systemd {
       command     => 'systemctl daemon-reload',
       refreshonly => true
     }
-
-    # refresh systemd before every service
-    Exec['systemd-daemon-reload'] -> Service<| |>
   }
 
 }


### PR DESCRIPTION
Hi,

I have a strange issue which I believe is caused by this 

Exec['systemd-daemon-reload'] -> Service<| |> in the main manifest.

https://github.com/justin8/justin8-systemd/blob/master/manifests/init.pp#L14

In one of my profile manifests I have the following:-

  service { 'pxp-agent':
    ensure => stopped,
    enable => false,
  }

With this included I get the following dependency cycle:-

==> dashboard: (Exec[systemd-daemon-reload] => Service[pxp-agent] => Class[Profile::Puppet] => Class[Profile] => Profile::Service[dashboard] => Systemd::Service[dashboard] => File[/etc/systemd/system/dashboard.service] => Exec[systemd-daemon-reload])

This is probably an issue with my particular setup but I was a bit confused as to why the Exec is included as from my understanding you only need to refresh systemd when the unit files change and this is already done as part of the defined type in https://github.com/justin8/justin8-systemd/blob/master/manifests/service.pp#L42

Hope this makes sense and feel free to reject if I'm wrong :) 

Perhaps @alexiri will be able to help?

Thanks,
Trevor

